### PR TITLE
[FIX] 루트 엔드포인트 NameError 해결

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,8 +24,7 @@ app.include_router(chat.router)
 @app.get("/")
 async def root():
     """루트 엔드포인트"""
-    # 의도적 버그: 존재하지 않는 변수 참조
-    return {"message": "Chat API Server", "version": undefined_variable}
+    return {"message": "Chat API Server"}
 
 
 @app.get("/health")


### PR DESCRIPTION
## 🐛 문제점
Issue #2에서 보고된 루트 엔드포인트(`/`)에서 `NameError: name 'undefined_variable' is not defined` 오류가 발생하는 문제를 해결했습니다.

## 🔧 해결 방법
- `backend/app/main.py`의 root 함수에서 정의되지 않은 변수 `undefined_variable` 참조 제거
- 정상적인 JSON 응답 `{"message": "Chat API Server"}`를 반환하도록 수정

## 📋 변경 사항
```python
# Before (버그)
return {"message": "Chat API Server", "version": undefined_variable}

# After (수정)
return {"message": "Chat API Server"}
```

## ✅ 테스트 결과
- 전체 테스트 스위트: **15/15 통과** ✅
- 특정 테스트: `test_read_root` 통과 확인 ✅

## 🔗 관련 이슈
Fixes #2

## 📝 체크리스트
- [x] 버그 수정 완료
- [x] 테스트 통과 확인
- [x] 코드 리뷰 준비 완료
- [x] 커밋 메시지 작성 완료